### PR TITLE
fix: add missing typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/core.js",
   "types": "dist/core.d.ts",
   "scripts": {
-    "start": "tsc && node dist/core.js",
+    "start": "tsc --noEmit && node dist/core.js",
     "build": "tsc"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
@@ -59,6 +59,7 @@
     /* Experimental Options */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Hello 🙌 
I was using this package and found there are no types. `dist/core.d.ts` was not emit while tsc. This PR fixes missing types by set `declaration: true` in tsconfig.json.

```json
{
  "name": "browser-thermal-printer",
  "version": "0.0.1",
  "description": "Print on Epson and Star thermal printers in a browser",
  "main": "dist/core.js",
  "types": "dist/core.d.ts",
  // ...
```

Before:
<img width="286" alt="no types" src="https://user-images.githubusercontent.com/13250888/176815717-d577e8e1-94a1-41c3-9038-ea3320688057.png">

After:
<img width="294" alt="added types" src="https://user-images.githubusercontent.com/13250888/176815732-6734fc1a-c632-45ac-9409-0ce6058175b6.png">
